### PR TITLE
Update shebangs for Python 3

### DIFF
--- a/os-cherry-pop.py
+++ b/os-cherry-pop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Proposes a list of downstream patches to cherry pick for a new release

--- a/os-upstream-sync.py
+++ b/os-upstream-sync.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Syncs a downstream fork of an OpenStack project with upstream.


### PR DESCRIPTION
Some platforms don't have an unversioned python binary.