### PR TITLE
Fix os-downstream-tag.py downstream tag matching

### DIFF
--- a/os-downstream-tag.py
+++ b/os-downstream-tag.py
@@ -9,6 +9,7 @@ repository.
 from __future__ import print_function
 import argparse
 import os
+import re
 import subprocess
 import sys
 
@@ -33,6 +34,28 @@ def most_recent_tag(ref):
     cmd = ["git", "describe", ref, "--exclude=*[a-z]", "--abbrev=0", "--tags"]
     output = subprocess.check_output(cmd)
     return output.decode(encoding=sys.stdout.encoding).strip()
+
+
+def most_recent_downstream_tag(ref, downstream_prefix, upstream_tag):
+    # List tags matching the expected pattern.
+    prefix = f"{downstream_prefix}{upstream_tag}"
+    cmd = ["git", "tag", "-l", f"{prefix}.*"]
+    output = subprocess.check_output(cmd)
+
+    # git tag -l <pattern> just does a shell match. Filter out any tags that
+    # aren't properly formatted.
+    tags = output.decode(encoding=sys.stdout.encoding).strip().splitlines()
+    pattern = re.compile(r"^" + re.escape(prefix) + r"\.[\d]+$")
+    tags = [t for t in tags if pattern.match(t)]
+    if not tags:
+        return
+
+    def tag_patch_key(tag):
+        # Sort based on the patch number.
+        patch = tag.split(".")[-1]
+        return int(patch, base=10)
+
+    return sorted(tags, key=tag_patch_key, reverse=True)[0]
 
 
 def merge_base(ref1, ref2):
@@ -93,33 +116,24 @@ def main():
     downstream_branch = "stackhpc/{}".format(release)
     downstream_ref = rev_parse("{}/{}".format(downstream_remote, downstream_branch))
 
-    downstream_tag = most_recent_tag(downstream_ref)
-    downstream_tag_ref = rev_parse(downstream_tag)
-
-    if downstream_tag_ref == downstream_ref:
-        print("Latest downstream commit is already tagged as", downstream_tag)
-        return
-
-    if downstream_tag.startswith(downstream_prefix):
-        print("Found downstream tag", downstream_tag)
-        downstream_tag_without_prefix = downstream_tag[len(downstream_prefix):]
-        dotted_split = downstream_tag_without_prefix.split('.')
-        if len(dotted_split) != 4:
-            print("Unable to parse most recent downstream tag", downstream_tag)
-            sys.exit(1)
-        downstream_base = ".".join(dotted_split[:3])
-        downstream_patch = int(dotted_split[3])
-    else:
-        downstream_base, downstream_patch = downstream_tag, 0
-        print("Found no downstream tag - basing off of upstream tag", downstream_base)
-
     merge_base_ref = merge_base(upstream_ref, downstream_ref)
     upstream_tag = most_recent_tag(merge_base_ref)
     print("Most recent upstream tag:", upstream_tag)
 
-    if downstream_base == upstream_tag:
+    downstream_tag = most_recent_downstream_tag(downstream_ref, downstream_prefix, upstream_tag)
+
+    if downstream_tag:
+        downstream_tag_ref = rev_parse(downstream_tag)
+
+        if downstream_tag_ref == downstream_ref:
+            print("Latest downstream commit is already tagged as", downstream_tag)
+            return
+
+        print("Found downstream tag", downstream_tag)
+        downstream_patch = int(downstream_tag.split('.')[-1])
         new_patch = int(downstream_patch) + 1
     else:
+        print("Found no downstream tag - basing off of upstream tag")
         new_patch = 1
 
     new_tag = "{}{}.{}".format(downstream_prefix, upstream_tag, new_patch)


### PR DESCRIPTION
If the most recent downstream tag is not patching the most recent
upstream tag, but there is another downstream tag that is patching the
most recent upstream tag, the next downstream tag would be chosen
incorrectly.

This is best shown with an example.

Run naming-things-is-hard/os-downstream-tag.py --release $(basename $(git rev-parse --abbrev-ref HEAD))
Fetching from origin
Fetching from stackhpc
Found downstream tag stackhpc/10.0.0.13
Merge base of 661f7c9fcef554deb7765fb4300ef045ef3d50a5 and 422be9f0d581d9caa0d161b6c54c90147feb7e4f is b'661f7c9fcef554deb7765fb4300ef045ef3d50a5'
Most recent upstream tag: 11.1.0
Error: stackhpc/11.1.0.1 already exists as an unreachable tag, please delete and retry
Error: Process completed with exit code 1.

The problem here is that it thinks that the most recent tag is
stackhpc/10.0.0.13, but actually there is stackhpc/11.1.0.3.

We have the wallaby tag stackhpc/10.0.0.13 in the commit history due to
merging stackhpc/wallaby into stackhpc/xena. This is not something we
typically do with OpenStack repositories, where the stable branches
diverge, however with kayobe-config it sometimes makes sense to do so.

This change fixes the issue by filtering the considered downstream tags
based on the most recent upstream tag.
