### PR TITLE
Fix upstream master ref syntax

### DIFF
--- a/os-downstream-tag.py
+++ b/os-downstream-tag.py
@@ -114,7 +114,7 @@ def main():
         "{}/stable/{}".format(upstream_remote, release),
         "{}/unmaintained/{}".format(upstream_remote, release),
         "{}-eol".format(release),
-        str(release),
+        "{}/{}".format(upstream_remote, release),
     ]
     for ref in upstream_refs:
         print(f"Checking for existence of upstream {ref}")


### PR DESCRIPTION
I made a mistake on https://github.com/stackhpc/naming-things-is-hard/pull/14, forgot to include the upstream remote in the ref.
was searching for `master` when it should really be `origin/master`