### PR TITLE
Add --copy-from-master option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,9 +30,10 @@ Tools
 
 ``os-cherry-pop.py``
     Proposes a list of downstream patches to cherry pick for a new release
-    branch. The list is generated based on the downstream patches in a previous
-    release, and accounts for patches that have been merged into the new
-    release. It also looks for newer versions of a patch on later branches.
+    branch. The list is generated based on the downstream patches, either from
+    a downstream master branch, or a previous release, accounting for patches
+    that have been merged into the new release. It also looks for newer
+    versions of a patch on later branches.
 
 ``os-downstream-tag.py``
     Determines an appropriate version to assign to a downstream fork of an


### PR DESCRIPTION
Added a new command line option, `--copy-from-master`, for cherry-picking patches from a downstream master branches to a new release branch.

Tested on a fork of Magnum. Will leave as draft until tested on real Epoxy branches, then mark as ready.